### PR TITLE
feat(web): add Dockerfile with multi-stage build

### DIFF
--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -1,0 +1,38 @@
+# use the official Bun image
+# see all versions at https://hub.docker.com/r/oven/bun/tags
+FROM oven/bun AS base
+WORKDIR /usr/src/app
+
+# install dependencies into temp directory
+# this will cache them and speed up future builds
+FROM base AS install
+RUN mkdir -p /temp/dev
+COPY package.json bun.lock /temp/dev/
+RUN cd /temp/dev && bun install --frozen-lockfile
+
+# install with --production (exclude devDependencies)
+RUN mkdir -p /temp/prod
+COPY package.json bun.lock /temp/prod/
+RUN cd /temp/prod && bun install --frozen-lockfile --production
+
+# copy node_modules from temp directory
+# then copy all (non-ignored) project files into the image
+FROM base AS prerelease
+COPY --from=install /temp/dev/node_modules node_modules
+COPY . .
+
+# tests & build
+ENV NODE_ENV=production
+RUN bun test
+RUN bun run build
+
+# copy production dependencies and source code into final image
+FROM base AS release
+COPY --from=install /temp/prod/node_modules node_modules
+COPY --from=prerelease /usr/src/app/dist dist
+COPY --from=prerelease /usr/src/app/package.json .
+
+# run the app
+USER bun
+EXPOSE 3001/tcp
+ENTRYPOINT [ "bun", "run", "dist/server.js" ]


### PR DESCRIPTION
## Summary
- Add multi-stage Dockerfile for the web app (Bun + Elysia)
- Stage 1: Install dependencies (cached separately for faster rebuilds)
- Stage 2: Run tests + build with dev dependencies
- Stage 3: Production image with only prod deps and `dist/`
- Runs as non-root `bun` user, exposes port 3001

## Test plan
- [ ] `docker build -t membooks-web web/` builds successfully
- [ ] `docker run -p 3001:3001 membooks-web` starts and serves the app

Closes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)