### PR TITLE
feat(api): add Swagger/OpenAPI documentation

### DIFF
--- a/api/bun.lock
+++ b/api/bun.lock
@@ -8,6 +8,7 @@
         "@elysiajs/cors": "^1.4.1",
         "@elysiajs/jwt": "^1.4.0",
         "@elysiajs/static": "^1.4.7",
+        "@elysiajs/swagger": "^1.3.1",
         "drizzle-orm": "^0.45.1",
         "elysia": "^1.4.22",
         "postgres": "^3.4.8",
@@ -18,7 +19,7 @@
         "drizzle-kit": "^0.31.8",
       },
       "peerDependencies": {
-        "typescript": "^5",
+        "typescript": "^5.9.3",
       },
     },
   },
@@ -32,6 +33,8 @@
     "@elysiajs/jwt": ["@elysiajs/jwt@1.4.0", "", { "dependencies": { "jose": "^6.0.11" }, "peerDependencies": { "elysia": ">= 1.4.0" } }, "sha512-Z0PvZhQxdDeKZ8HslXzDoXXD83NKExNPmoiAPki3nI2Xvh5wtUrBH+zWOD17yP14IbRo8fxGj3L25MRCAPsgPA=="],
 
     "@elysiajs/static": ["@elysiajs/static@1.4.7", "", { "peerDependencies": { "elysia": ">= 1.4.0" } }, "sha512-Go4kIXZ0G3iWfkAld07HmLglqIDMVXdyRKBQK/sVEjtpDdjHNb+rUIje73aDTWpZYg4PEVHUpi9v4AlNEwrQug=="],
+
+    "@elysiajs/swagger": ["@elysiajs/swagger@1.3.1", "", { "dependencies": { "@scalar/themes": "^0.9.52", "@scalar/types": "^0.0.12", "openapi-types": "^12.1.3", "pathe": "^1.1.2" }, "peerDependencies": { "elysia": ">= 1.3.0" } }, "sha512-LcbLHa0zE6FJKWPWKsIC/f+62wbDv3aXydqcNPVPyqNcaUgwvCajIi+5kHEU6GO3oXUCpzKaMsb3gsjt8sLzFQ=="],
 
     "@esbuild-kit/core-utils": ["@esbuild-kit/core-utils@3.3.2", "", { "dependencies": { "esbuild": "~0.18.20", "source-map-support": "^0.5.21" } }, "sha512-sPRAnw9CdSsRmEtnsl2WXWdyquogVpB3yZ3dgwJfe8zrOzTsV7cJvmwrKVa+0ma5BoiGJ+BoqkMvawbayKUsqQ=="],
 
@@ -89,6 +92,12 @@
 
     "@esbuild/win32-x64": ["@esbuild/win32-x64@0.25.12", "", { "os": "win32", "cpu": "x64" }, "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA=="],
 
+    "@scalar/openapi-types": ["@scalar/openapi-types@0.1.1", "", {}, "sha512-NMy3QNk6ytcCoPUGJH0t4NNr36OWXgZhA3ormr3TvhX1NDgoF95wFyodGVH8xiHeUyn2/FxtETm8UBLbB5xEmg=="],
+
+    "@scalar/themes": ["@scalar/themes@0.9.86", "", { "dependencies": { "@scalar/types": "0.1.7" } }, "sha512-QUHo9g5oSWi+0Lm1vJY9TaMZRau8LHg+vte7q5BVTBnu6NuQfigCaN+ouQ73FqIVd96TwMO6Db+dilK1B+9row=="],
+
+    "@scalar/types": ["@scalar/types@0.0.12", "", { "dependencies": { "@scalar/openapi-types": "0.1.1", "@unhead/schema": "^1.9.5" } }, "sha512-XYZ36lSEx87i4gDqopQlGCOkdIITHHEvgkuJFrXFATQs9zHARop0PN0g4RZYWj+ZpCUclOcaOjbCt8JGe22mnQ=="],
+
     "@sinclair/typebox": ["@sinclair/typebox@0.34.47", "", {}, "sha512-ZGIBQ+XDvO5JQku9wmwtabcVTHJsgSWAHYtVuM9pBNNR5E88v6Jcj/llpmsjivig5X8A8HHOb4/mbEKPS5EvAw=="],
 
     "@tokenizer/inflate": ["@tokenizer/inflate@0.4.1", "", { "dependencies": { "debug": "^4.4.3", "token-types": "^6.1.1" } }, "sha512-2mAv+8pkG6GIZiF1kNg1jAjh27IDxEPKwdGul3snfztFerfPGI1LjDezZp3i7BElXompqEtPmoPx6c2wgtWsOA=="],
@@ -98,6 +107,8 @@
     "@types/bun": ["@types/bun@1.3.6", "", { "dependencies": { "bun-types": "1.3.6" } }, "sha512-uWCv6FO/8LcpREhenN1d1b6fcspAB+cefwD7uti8C8VffIv0Um08TKMn98FynpTiU38+y2dUO55T11NgDt8VAA=="],
 
     "@types/node": ["@types/node@25.0.10", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-zWW5KPngR/yvakJgGOmZ5vTBemDoSqF3AcV/LrO5u5wTWyEAVVh+IT39G4gtyAkh3CtTZs8aX/yRM82OfzHJRg=="],
+
+    "@unhead/schema": ["@unhead/schema@1.11.20", "", { "dependencies": { "hookable": "^5.5.3", "zhead": "^2.2.4" } }, "sha512-0zWykKAaJdm+/Y7yi/Yds20PrUK7XabLe9c3IRcjnwYmSWY6z0Cr19VIs3ozCj8P+GhR+/TI2mwtGlueCEYouA=="],
 
     "buffer-from": ["buffer-from@1.1.2", "", {}, "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="],
 
@@ -149,6 +160,8 @@
 
     "hasown": ["hasown@2.0.2", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ=="],
 
+    "hookable": ["hookable@5.5.3", "", {}, "sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ=="],
+
     "ieee754": ["ieee754@1.2.1", "", {}, "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="],
 
     "jose": ["jose@6.1.3", "", {}, "sha512-0TpaTfihd4QMNwrz/ob2Bp7X04yuxJkjRGi4aKmOqwhov54i6u79oCv7T+C7lo70MKH6BesI3vscD1yb/yzKXQ=="],
@@ -159,9 +172,13 @@
 
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
+    "nanoid": ["nanoid@5.1.6", "", { "bin": { "nanoid": "bin/nanoid.js" } }, "sha512-c7+7RQ+dMB5dPwwCp4ee1/iV/q2P6aK1mTZcfr1BTuVlyW9hJYiMPybJCcnBlQtuSmTIWNeazm/zqNoZSSElBg=="],
+
     "object-inspect": ["object-inspect@1.13.4", "", {}, "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew=="],
 
     "openapi-types": ["openapi-types@12.1.3", "", {}, "sha512-N4YtSYJqghVu4iek2ZUvcN/0aqH1kRDuNqzcycDxhOUpg7GdvLa2F3DgS6yBNhInhv2r/6I0Flkn7CqL8+nIcw=="],
+
+    "pathe": ["pathe@1.1.2", "", {}, "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ=="],
 
     "postgres": ["postgres@3.4.8", "", {}, "sha512-d+JFcLM17njZaOLkv6SCev7uoLaBtfK86vMUXhW1Z4glPWh4jozno9APvW/XKFJ3CCxVoC7OL38BqRydtu5nGg=="],
 
@@ -187,13 +204,21 @@
 
     "token-types": ["token-types@6.1.2", "", { "dependencies": { "@borewit/text-codec": "^0.2.1", "@tokenizer/token": "^0.3.0", "ieee754": "^1.2.1" } }, "sha512-dRXchy+C0IgK8WPC6xvCHFRIWYUbqqdEIKPaKo/AcTUNzwLTK6AH7RjdLWsEZcAN/TBdtfUw3PYEgPr5VPr6ww=="],
 
+    "type-fest": ["type-fest@4.41.0", "", {}, "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA=="],
+
     "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 
     "uint8array-extras": ["uint8array-extras@1.5.0", "", {}, "sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A=="],
 
     "undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
 
+    "zhead": ["zhead@2.2.4", "", {}, "sha512-8F0OI5dpWIA5IGG5NHUg9staDwz/ZPxZtvGVf01j7vHqSyZ0raHY+78atOVxRqb73AotX22uV1pXt3gYSstGag=="],
+
+    "zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+
     "@esbuild-kit/core-utils/esbuild": ["esbuild@0.18.20", "", { "optionalDependencies": { "@esbuild/android-arm": "0.18.20", "@esbuild/android-arm64": "0.18.20", "@esbuild/android-x64": "0.18.20", "@esbuild/darwin-arm64": "0.18.20", "@esbuild/darwin-x64": "0.18.20", "@esbuild/freebsd-arm64": "0.18.20", "@esbuild/freebsd-x64": "0.18.20", "@esbuild/linux-arm": "0.18.20", "@esbuild/linux-arm64": "0.18.20", "@esbuild/linux-ia32": "0.18.20", "@esbuild/linux-loong64": "0.18.20", "@esbuild/linux-mips64el": "0.18.20", "@esbuild/linux-ppc64": "0.18.20", "@esbuild/linux-riscv64": "0.18.20", "@esbuild/linux-s390x": "0.18.20", "@esbuild/linux-x64": "0.18.20", "@esbuild/netbsd-x64": "0.18.20", "@esbuild/openbsd-x64": "0.18.20", "@esbuild/sunos-x64": "0.18.20", "@esbuild/win32-arm64": "0.18.20", "@esbuild/win32-ia32": "0.18.20", "@esbuild/win32-x64": "0.18.20" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-ceqxoedUrcayh7Y7ZX6NdbbDzGROiyVBgC4PriJThBKSVPWnnFHZAkfI1lJT8QFkOwH4qOS2SJkS4wvpGl8BpA=="],
+
+    "@scalar/themes/@scalar/types": ["@scalar/types@0.1.7", "", { "dependencies": { "@scalar/openapi-types": "0.2.0", "@unhead/schema": "^1.11.11", "nanoid": "^5.1.5", "type-fest": "^4.20.0", "zod": "^3.23.8" } }, "sha512-irIDYzTQG2KLvFbuTI8k2Pz/R4JR+zUUSykVTbEMatkzMmVFnn1VzNSMlODbadycwZunbnL2tA27AXed9URVjw=="],
 
     "@esbuild-kit/core-utils/esbuild/@esbuild/android-arm": ["@esbuild/android-arm@0.18.20", "", { "os": "android", "cpu": "arm" }, "sha512-fyi7TDI/ijKKNZTUJAQqiG5T7YjJXgnzkURqmGj13C6dCqckZBLdl4h7bkhHt/t0WP+zO9/zwroDvANaOqO5Sw=="],
 
@@ -238,5 +263,7 @@
     "@esbuild-kit/core-utils/esbuild/@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.18.20", "", { "os": "win32", "cpu": "ia32" }, "sha512-Wv7QBi3ID/rROT08SABTS7eV4hX26sVduqDOTe1MvGMjNd3EjOz4b7zeexIR62GTIEKrfJXKL9LFxTYgkyeu7g=="],
 
     "@esbuild-kit/core-utils/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.18.20", "", { "os": "win32", "cpu": "x64" }, "sha512-kTdfRcSiDfQca/y9QIkng02avJ+NCaQvrMejlsB3RRv5sE9rRoeBPISaZpKxHELzRxZyLvNts1P27W3wV+8geQ=="],
+
+    "@scalar/themes/@scalar/types/@scalar/openapi-types": ["@scalar/openapi-types@0.2.0", "", { "dependencies": { "zod": "^3.23.8" } }, "sha512-waiKk12cRCqyUCWTOX0K1WEVX46+hVUK+zRPzAahDJ7G0TApvbNkuy5wx7aoUyEk++HHde0XuQnshXnt8jsddA=="],
   }
 }

--- a/api/package.json
+++ b/api/package.json
@@ -23,6 +23,7 @@
     "@elysiajs/cors": "^1.4.1",
     "@elysiajs/jwt": "^1.4.0",
     "@elysiajs/static": "^1.4.7",
+    "@elysiajs/swagger": "^1.3.1",
     "drizzle-orm": "^0.45.1",
     "elysia": "^1.4.22",
     "postgres": "^3.4.8",

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -1,5 +1,6 @@
 import { Elysia } from "elysia";
 import { cors } from "@elysiajs/cors";
+import { swagger } from "@elysiajs/swagger";
 import { authRoutes } from "./routes/auth";
 import { subscriptionRoutes, webhookRoutes } from "./routes/subscription";
 import { adminRoutes } from "./routes/admin";
@@ -13,6 +14,35 @@ const app = new Elysia()
     cors({
       origin: allowedOrigins.length > 0 ? allowedOrigins : true,
       credentials: true,
+    })
+  )
+  .use(
+    swagger({
+      path: "/swagger",
+      documentation: {
+        info: {
+          title: "Membooks API",
+          version: "1.0.0",
+          description:
+            "API for Membooks — a book tracking application. Manage user accounts, premium subscriptions via Stripe, and admin operations.",
+        },
+        tags: [
+          { name: "General", description: "Health check and root endpoints" },
+          { name: "Auth", description: "User authentication and account management" },
+          { name: "Subscription", description: "Premium subscription management via Stripe" },
+          { name: "Webhook", description: "Stripe webhook handler" },
+          { name: "Admin", description: "Admin dashboard and user management" },
+        ],
+        components: {
+          securitySchemes: {
+            bearerAuth: {
+              type: "http",
+              scheme: "bearer",
+              bearerFormat: "JWT",
+            },
+          },
+        },
+      },
     })
   )
   // Global error handler to ensure JSON responses
@@ -35,8 +65,12 @@ const app = new Elysia()
     const errorMessage = error instanceof Error ? error.message : String(error);
     return { error: "Internal Server Error", message: errorMessage };
   })
-  .get("/", () => ({ message: "Membooks API is running" }))
-  .get("/health", () => ({ status: "ok", timestamp: new Date().toISOString() }))
+  .get("/", () => ({ message: "Membooks API is running" }), {
+    detail: { tags: ["General"], summary: "Root", description: "Returns a simple message confirming the API is running." },
+  })
+  .get("/health", () => ({ status: "ok", timestamp: new Date().toISOString() }), {
+    detail: { tags: ["General"], summary: "Health check", description: "Returns the current health status and server timestamp." },
+  })
   .use(authRoutes)
   .use(subscriptionRoutes)
   .use(webhookRoutes)

--- a/api/src/routes/admin.ts
+++ b/api/src/routes/admin.ts
@@ -68,6 +68,8 @@ export const adminRoutes = new Elysia({ prefix: "/admin" })
         ? ((premiumUsers.count / totalUsers.count) * 100).toFixed(1)
         : 0,
     };
+  }, {
+    detail: { tags: ["Admin"], summary: "Dashboard stats", description: "Get platform statistics (total users, premium users, conversion rate). Requires admin access.", security: [{ bearerAuth: [] }] },
   })
   // List all users
   .get("/users", async ({ isAdmin, set, query }) => {
@@ -105,6 +107,8 @@ export const adminRoutes = new Elysia({ prefix: "/admin" })
         totalPages: Math.ceil(total.count / limit),
       },
     };
+  }, {
+    detail: { tags: ["Admin"], summary: "List users", description: "List all users with pagination. Requires admin access.", security: [{ bearerAuth: [] }] },
   })
   // Get single user with subscription
   .get("/users/:id", async ({ isAdmin, set, params }) => {
@@ -137,6 +141,8 @@ export const adminRoutes = new Elysia({ prefix: "/admin" })
     });
 
     return { user, subscription };
+  }, {
+    detail: { tags: ["Admin"], summary: "Get user details", description: "Get a single user's profile and subscription details. Requires admin access.", security: [{ bearerAuth: [] }] },
   })
   // Toggle premium status manually
   .post(
@@ -172,6 +178,7 @@ export const adminRoutes = new Elysia({ prefix: "/admin" })
       body: t.Object({
         isPremium: t.Boolean(),
       }),
+      detail: { tags: ["Admin"], summary: "Toggle premium status", description: "Manually toggle a user's premium status. Requires admin access.", security: [{ bearerAuth: [] }] },
     }
   )
   // List all subscriptions
@@ -213,4 +220,6 @@ export const adminRoutes = new Elysia({ prefix: "/admin" })
         totalPages: Math.ceil(total.count / limit),
       },
     };
+  }, {
+    detail: { tags: ["Admin"], summary: "List subscriptions", description: "List all subscriptions with user info and pagination. Requires admin access.", security: [{ bearerAuth: [] }] },
   });

--- a/api/src/routes/auth.ts
+++ b/api/src/routes/auth.ts
@@ -72,6 +72,7 @@ export const authRoutes = new Elysia({ prefix: "/auth" })
         password: t.String({ minLength: 8 }),
         language: t.Optional(t.String()),
       }),
+      detail: { tags: ["Auth"], summary: "Register", description: "Create a new user account and return a JWT token." },
     }
   )
   .post(
@@ -117,6 +118,7 @@ export const authRoutes = new Elysia({ prefix: "/auth" })
         email: t.String({ format: "email" }),
         password: t.String(),
       }),
+      detail: { tags: ["Auth"], summary: "Login", description: "Authenticate with email and password, returns a JWT token." },
     }
   )
   .get(
@@ -155,6 +157,9 @@ export const authRoutes = new Elysia({ prefix: "/auth" })
       }
 
       return { user };
+    },
+    {
+      detail: { tags: ["Auth"], summary: "Get current user", description: "Return the authenticated user's profile. Requires Bearer token.", security: [{ bearerAuth: [] }] },
     }
   )
   .put(
@@ -212,6 +217,7 @@ export const authRoutes = new Elysia({ prefix: "/auth" })
         username: t.Optional(t.String({ minLength: 3, maxLength: 30 })),
         language: t.Optional(t.String()),
       }),
+      detail: { tags: ["Auth"], summary: "Update profile", description: "Update the authenticated user's username or language. Requires Bearer token.", security: [{ bearerAuth: [] }] },
     }
   )
   .delete(
@@ -244,6 +250,9 @@ export const authRoutes = new Elysia({ prefix: "/auth" })
       await db.delete(users).where(eq(users.id, payload.sub as string));
 
       return { success: true };
+    },
+    {
+      detail: { tags: ["Auth"], summary: "Delete account", description: "Permanently delete the authenticated user's account. Requires Bearer token.", security: [{ bearerAuth: [] }] },
     }
   )
   .put(
@@ -299,5 +308,6 @@ export const authRoutes = new Elysia({ prefix: "/auth" })
         currentPassword: t.String(),
         newPassword: t.String({ minLength: 8 }),
       }),
+      detail: { tags: ["Auth"], summary: "Change password", description: "Change the authenticated user's password. Requires Bearer token.", security: [{ bearerAuth: [] }] },
     }
   );

--- a/api/src/routes/subscription.ts
+++ b/api/src/routes/subscription.ts
@@ -114,6 +114,9 @@ export const subscriptionRoutes = new Elysia({ prefix: "/subscription" })
       });
 
       return { url: session.url };
+    },
+    {
+      detail: { tags: ["Subscription"], summary: "Create checkout session", description: "Create a Stripe checkout session for premium subscription. Requires Bearer token.", security: [{ bearerAuth: [] }] },
     }
   )
   // Get current subscription status
@@ -158,6 +161,9 @@ export const subscriptionRoutes = new Elysia({ prefix: "/subscription" })
             }
           : null,
       };
+    },
+    {
+      detail: { tags: ["Subscription"], summary: "Get subscription status", description: "Return the current user's premium and subscription status. Requires Bearer token.", security: [{ bearerAuth: [] }] },
     }
   )
   // Cancel subscription
@@ -212,6 +218,9 @@ export const subscriptionRoutes = new Elysia({ prefix: "/subscription" })
         .where(eq(subscriptions.id, subscription.id));
 
       return { success: true };
+    },
+    {
+      detail: { tags: ["Subscription"], summary: "Cancel subscription", description: "Cancel the current subscription at period end. Requires Bearer token.", security: [{ bearerAuth: [] }] },
     }
   )
   // Reactivate subscription (if canceled but still in period)
@@ -266,6 +275,9 @@ export const subscriptionRoutes = new Elysia({ prefix: "/subscription" })
         .where(eq(subscriptions.id, subscription.id));
 
       return { success: true };
+    },
+    {
+      detail: { tags: ["Subscription"], summary: "Reactivate subscription", description: "Reactivate a canceled subscription before the current period ends. Requires Bearer token.", security: [{ bearerAuth: [] }] },
     }
   );
 
@@ -401,5 +413,8 @@ export const webhookRoutes = new Elysia({ prefix: "/webhook" }).post(
     }
 
     return { received: true };
+  },
+  {
+    detail: { tags: ["Webhook"], summary: "Stripe webhook", description: "Handle Stripe webhook events (checkout.session.completed, subscription updates, payment failures)." },
   }
 );

--- a/api/src/swagger.test.ts
+++ b/api/src/swagger.test.ts
@@ -1,0 +1,104 @@
+import { describe, test, expect } from "bun:test";
+import { Elysia } from "elysia";
+import { swagger } from "@elysiajs/swagger";
+
+const createAppWithSwagger = () => {
+  return new Elysia()
+    .use(
+      swagger({
+        path: "/swagger",
+        documentation: {
+          info: {
+            title: "Membooks API",
+            version: "1.0.0",
+            description:
+              "API for Membooks — a book tracking application. Manage user accounts, premium subscriptions via Stripe, and admin operations.",
+          },
+          tags: [
+            { name: "General", description: "Health check and root endpoints" },
+            { name: "Auth", description: "User authentication and account management" },
+            { name: "Subscription", description: "Premium subscription management via Stripe" },
+            { name: "Webhook", description: "Stripe webhook handler" },
+            { name: "Admin", description: "Admin dashboard and user management" },
+          ],
+          components: {
+            securitySchemes: {
+              bearerAuth: {
+                type: "http",
+                scheme: "bearer",
+                bearerFormat: "JWT",
+              },
+            },
+          },
+        },
+      })
+    )
+    .get("/", () => ({ message: "Membooks API is running" }), {
+      detail: { tags: ["General"], summary: "Root" },
+    })
+    .get("/health", () => ({ status: "ok" }), {
+      detail: { tags: ["General"], summary: "Health check" },
+    });
+};
+
+describe("Swagger Documentation", () => {
+  test("should serve Swagger UI at /swagger", async () => {
+    const app = createAppWithSwagger();
+    const response = await app.handle(new Request("http://localhost/swagger"));
+    expect(response.status).toBe(200);
+    const html = await response.text();
+    expect(html).toContain("html");
+  });
+
+  test("should serve OpenAPI JSON spec", async () => {
+    const app = createAppWithSwagger();
+    const response = await app.handle(new Request("http://localhost/swagger/json"));
+    expect(response.status).toBe(200);
+    const spec = await response.json();
+    expect(spec.openapi).toBeDefined();
+    expect(spec.info.title).toBe("Membooks API");
+    expect(spec.info.version).toBe("1.0.0");
+    expect(spec.info.description).toContain("Membooks");
+  });
+
+  test("should include all defined tags in spec", async () => {
+    const app = createAppWithSwagger();
+    const response = await app.handle(new Request("http://localhost/swagger/json"));
+    const spec = await response.json();
+    const tagNames = spec.tags.map((t: { name: string }) => t.name);
+    expect(tagNames).toContain("General");
+    expect(tagNames).toContain("Auth");
+    expect(tagNames).toContain("Subscription");
+    expect(tagNames).toContain("Webhook");
+    expect(tagNames).toContain("Admin");
+  });
+
+  test("should include bearer auth security scheme", async () => {
+    const app = createAppWithSwagger();
+    const response = await app.handle(new Request("http://localhost/swagger/json"));
+    const spec = await response.json();
+    const bearerAuth = spec.components?.securitySchemes?.bearerAuth;
+    expect(bearerAuth).toBeDefined();
+    expect(bearerAuth.type).toBe("http");
+    expect(bearerAuth.scheme).toBe("bearer");
+    expect(bearerAuth.bearerFormat).toBe("JWT");
+  });
+
+  test("should document registered endpoints with tags", async () => {
+    const app = createAppWithSwagger();
+    const response = await app.handle(new Request("http://localhost/swagger/json"));
+    const spec = await response.json();
+    expect(spec.paths["/"]).toBeDefined();
+    expect(spec.paths["/"].get.tags).toContain("General");
+    expect(spec.paths["/health"]).toBeDefined();
+    expect(spec.paths["/health"].get.tags).toContain("General");
+  });
+
+  test("should include endpoint summaries", async () => {
+    const app = createAppWithSwagger();
+    const response = await app.handle(new Request("http://localhost/swagger/json"));
+    const spec = await response.json();
+    expect(spec.paths["/"].get.summary).toBe("Root");
+    expect(spec.paths["/health"].get.summary).toBe("Health check");
+  });
+});


### PR DESCRIPTION
## Summary
- Install `@elysiajs/swagger` and expose interactive API docs at `/swagger`
- Tag all endpoints (General, Auth, Subscription, Webhook, Admin) with summaries and descriptions
- Add JWT Bearer auth security scheme to the OpenAPI spec
- Add 6 unit tests verifying Swagger UI, OpenAPI JSON spec, tags, security scheme, and endpoint documentation

Closes #16

## Test plan
- [x] Run `bun test src/swagger.test.ts` — 6 tests pass
- [x] Run `bun test` — all 61 tests pass
- [x] Start the API and navigate to `/swagger` to verify interactive docs render
- [x] Verify all endpoints are documented with correct tags and descriptions

🤖 Generated with [Claude Code](https://claude.com/claude-code)