### PR TITLE
feat(mobile): improve UI consistency and visual polish

### DIFF
--- a/mobile/__mocks__/setup.ts
+++ b/mobile/__mocks__/setup.ts
@@ -36,6 +36,7 @@ mock.module('react-native', () => {
     TextInput: (props: any) => React.createElement('TextInput', props),
     ScrollView: ({ children, ...props }: any) => React.createElement('ScrollView', props, children),
     ActivityIndicator: (props: any) => React.createElement('ActivityIndicator', props),
+    KeyboardAvoidingView: ({ children, ...props }: any) => React.createElement('View', props, children),
     Alert: {
       alert: mock(),
     },

--- a/mobile/__tests__/components/ui-improvements.test.tsx
+++ b/mobile/__tests__/components/ui-improvements.test.tsx
@@ -1,0 +1,150 @@
+import { describe, it, expect, mock } from 'bun:test';
+import React from 'react';
+import { render } from '@testing-library/react-native';
+
+// Mock hooks
+mock.module('@/hooks/use-theme-colors', () => ({
+  useThemeColors: () => ({
+    background: '#F5F5F0',
+    backgroundSecondary: '#FFFFFF',
+    backgroundAccent: '#FFE66D',
+    text: '#000000',
+    textSecondary: '#444444',
+    textMuted: '#999999',
+    textInverse: '#FFFFFF',
+    border: '#000000',
+    borderLight: '#CCCCCC',
+    primary: '#FF6B6B',
+    primaryText: '#000000',
+    secondary: '#4ECDC4',
+    secondaryText: '#000000',
+    accent1: '#FFE66D',
+    accent2: '#9B5DE5',
+    accent3: '#F15BB5',
+    accent4: '#00BBF9',
+    shadow: '#000000',
+    success: '#00C851',
+    warning: '#FFBB33',
+    error: '#FF4444',
+    info: '#33B5E5',
+  }),
+}));
+
+// Mock auth context
+mock.module('@/contexts/auth-context', () => ({
+  useAuth: () => ({
+    login: mock(() => Promise.resolve({ success: true })),
+    register: mock(() => Promise.resolve({ success: true })),
+    socialLogin: mock(() => Promise.resolve({ success: true })),
+    user: { username: 'testuser' },
+    isAuthenticated: false,
+    logout: mock(),
+  }),
+}));
+
+const ReactRef = require('react');
+
+// Mock books context
+mock.module('@/contexts/books-context', () => ({
+  useBooks: () => ({
+    ownedBooks: [],
+    wishlistBooks: [],
+    upcomingBooks: [],
+    series: [],
+    isLoading: false,
+  }),
+}));
+
+// Mock social auth buttons
+mock.module('@/components/social-auth-buttons', () => ({
+  SocialAuthButtons: () => ReactRef.createElement('View', { testID: 'social-auth' }),
+}));
+
+// Mock @expo/vector-icons
+mock.module('@expo/vector-icons', () => ({
+  Ionicons: ({ name, ...props }: any) =>
+    ReactRef.createElement('Text', { ...props, testID: `icon-${name}` }, name),
+}));
+
+// Import components after mocks
+const LoginScreen = require('@/app/(auth)/login').default;
+const RegisterScreen = require('@/app/(auth)/register').default;
+const Home = require('@/app/(tabs)/index').default;
+const ProposalsScreen = require('@/app/(tabs)/proposals').default;
+
+describe('Auth screens theme consistency', () => {
+  it('login screen renders with theme colors', () => {
+    const { getByText } = render(<LoginScreen />);
+    expect(getByText('Membooks')).toBeTruthy();
+    expect(getByText('auth.login.button')).toBeTruthy();
+  });
+
+  it('register screen renders with theme colors', () => {
+    const { getByText } = render(<RegisterScreen />);
+    expect(getByText('Membooks')).toBeTruthy();
+    expect(getByText('auth.register.button')).toBeTruthy();
+  });
+
+  it('login screen renders email and password labels', () => {
+    const { getByText } = render(<LoginScreen />);
+    expect(getByText('auth.email')).toBeTruthy();
+    expect(getByText('auth.password')).toBeTruthy();
+  });
+
+  it('register screen renders all input labels', () => {
+    const { getByText } = render(<RegisterScreen />);
+    expect(getByText('auth.username')).toBeTruthy();
+    expect(getByText('auth.email')).toBeTruthy();
+    expect(getByText('auth.password')).toBeTruthy();
+    expect(getByText('auth.confirmPassword')).toBeTruthy();
+  });
+});
+
+describe('Empty states with icons', () => {
+  it('home screen renders book icon in empty myBooks state', () => {
+    const { getByTestId } = render(<Home />);
+    expect(getByTestId('icon-book-outline')).toBeTruthy();
+  });
+
+  it('home screen renders empty library text', () => {
+    const { getByText } = render(<Home />);
+    expect(getByText('home.emptyLibrary')).toBeTruthy();
+  });
+});
+
+describe('Proposals screen', () => {
+  it('renders enhanced placeholder with icon', () => {
+    const { getByTestId } = render(<ProposalsScreen />);
+    expect(getByTestId('icon-bulb-outline')).toBeTruthy();
+  });
+
+  it('renders coming soon title', () => {
+    const { getByText } = render(<ProposalsScreen />);
+    expect(getByText('home.comingSoon')).toBeTruthy();
+  });
+
+  it('renders subtitle text', () => {
+    const { getByText } = render(<ProposalsScreen />);
+    expect(getByText('proposals.subtitle')).toBeTruthy();
+  });
+});
+
+describe('Input focus states', () => {
+  it('login email input has onFocus and onBlur handlers', () => {
+    const { UNSAFE_getAllByType } = render(<LoginScreen />);
+    const { TextInput } = require('react-native');
+    const inputs = UNSAFE_getAllByType(TextInput);
+    const emailInput = inputs[0];
+    expect(emailInput.props.onFocus).toBeDefined();
+    expect(emailInput.props.onBlur).toBeDefined();
+  });
+
+  it('register username input has onFocus and onBlur handlers', () => {
+    const { UNSAFE_getAllByType } = render(<RegisterScreen />);
+    const { TextInput } = require('react-native');
+    const inputs = UNSAFE_getAllByType(TextInput);
+    const usernameInput = inputs[0];
+    expect(usernameInput.props.onFocus).toBeDefined();
+    expect(usernameInput.props.onBlur).toBeDefined();
+  });
+});

--- a/mobile/app/(auth)/login.tsx
+++ b/mobile/app/(auth)/login.tsx
@@ -9,7 +9,6 @@ import {
   Platform,
   ScrollView,
   ActivityIndicator,
-  useColorScheme,
 } from "react-native";
 import { Ionicons } from "@expo/vector-icons";
 import { Link } from "expo-router";
@@ -18,20 +17,21 @@ import * as AppleAuthentication from "expo-apple-authentication";
 import { useAuth } from "@/contexts/auth-context";
 import { LanguageContext } from "@/contexts/language-context";
 import { SocialAuthButtons } from "@/components/social-auth-buttons";
-import { lightColors, darkColors, spacing, borderRadius } from "@/constants";
+import { useThemeColors } from "@/hooks/use-theme-colors";
+import { spacing, typography, borders, shadows } from "@/constants";
 
 export default function LoginScreen() {
   const { t } = useTranslation();
   const { login, socialLogin } = useAuth();
   const languageContext = useContext(LanguageContext);
-  const colorScheme = useColorScheme();
-  const colors = colorScheme === "dark" ? darkColors : lightColors;
+  const colors = useThemeColors();
 
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [showPassword, setShowPassword] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [focusedField, setFocusedField] = useState<string | null>(null);
 
   const handleLogin = async () => {
     if (!email.trim() || !password.trim()) {
@@ -102,11 +102,9 @@ export default function LoginScreen() {
     }
   };
 
-  const styles = createStyles(colors);
-
   return (
     <KeyboardAvoidingView
-      style={styles.container}
+      style={[styles.container, { backgroundColor: colors.background }]}
       behavior={Platform.OS === "ios" ? "padding" : "height"}
     >
       <ScrollView
@@ -114,22 +112,53 @@ export default function LoginScreen() {
         keyboardShouldPersistTaps="handled"
       >
         <View style={styles.header}>
-          <Text style={styles.logo}>Membooks</Text>
+          <Text style={[styles.logo, { color: colors.primary }]}>Membooks</Text>
         </View>
 
-        <View style={styles.form}>
+        <View
+          style={[
+            styles.form,
+            {
+              backgroundColor: colors.backgroundSecondary,
+              borderColor: colors.border,
+            },
+          ]}
+        >
           {error && (
-            <View style={styles.errorContainer}>
-              <Text style={styles.errorText}>{error}</Text>
+            <View
+              style={[
+                styles.errorContainer,
+                {
+                  backgroundColor: colors.error + "20",
+                  borderColor: colors.error,
+                },
+              ]}
+            >
+              <Text style={[styles.errorText, { color: colors.error }]}>
+                {error}
+              </Text>
             </View>
           )}
 
           <View style={styles.inputGroup}>
-            <Text style={styles.label}>{t("auth.email")}</Text>
+            <Text style={[styles.label, { color: colors.text }]}>
+              {t("auth.email")}
+            </Text>
             <TextInput
-              style={styles.input}
+              style={[
+                styles.input,
+                {
+                  backgroundColor: colors.background,
+                  borderColor: focusedField === "email" ? colors.primary : colors.border,
+                  color: colors.text,
+                  shadowColor: colors.shadow,
+                },
+                focusedField === "email" && styles.inputFocused,
+              ]}
               value={email}
               onChangeText={setEmail}
+              onFocus={() => setFocusedField("email")}
+              onBlur={() => setFocusedField(null)}
               placeholder={t("auth.emailPlaceholder")}
               placeholderTextColor={colors.textMuted}
               keyboardType="email-address"
@@ -140,12 +169,26 @@ export default function LoginScreen() {
           </View>
 
           <View style={styles.inputGroup}>
-            <Text style={styles.label}>{t("auth.password")}</Text>
-            <View style={styles.passwordContainer}>
+            <Text style={[styles.label, { color: colors.text }]}>
+              {t("auth.password")}
+            </Text>
+            <View
+              style={[
+                styles.passwordContainer,
+                {
+                  backgroundColor: colors.background,
+                  borderColor: focusedField === "password" ? colors.primary : colors.border,
+                  shadowColor: colors.shadow,
+                },
+                focusedField === "password" && styles.inputFocused,
+              ]}
+            >
               <TextInput
-                style={styles.passwordInput}
+                style={[styles.passwordInput, { color: colors.text }]}
                 value={password}
                 onChangeText={setPassword}
+                onFocus={() => setFocusedField("password")}
+                onBlur={() => setFocusedField(null)}
                 placeholder={t("auth.passwordPlaceholder")}
                 placeholderTextColor={colors.textMuted}
                 secureTextEntry={!showPassword}
@@ -167,14 +210,23 @@ export default function LoginScreen() {
           </View>
 
           <Pressable
-            style={[styles.button, isLoading && styles.buttonDisabled]}
+            style={[
+              styles.button,
+              {
+                backgroundColor: colors.primary,
+                borderColor: colors.border,
+              },
+              isLoading && styles.buttonDisabled,
+            ]}
             onPress={handleLogin}
             disabled={isLoading}
           >
             {isLoading ? (
               <ActivityIndicator color={colors.primaryText} />
             ) : (
-              <Text style={styles.buttonText}>{t("auth.login.button")}</Text>
+              <Text style={[styles.buttonText, { color: colors.primaryText }]}>
+                {t("auth.login.button")}
+              </Text>
             )}
           </Pressable>
 
@@ -188,10 +240,14 @@ export default function LoginScreen() {
           />
 
           <View style={styles.footer}>
-            <Text style={styles.footerText}>{t("auth.login.noAccount")}</Text>
+            <Text style={[styles.footerText, { color: colors.textSecondary }]}>
+              {t("auth.login.noAccount")}
+            </Text>
             <Link href="/(auth)/register" asChild>
               <Pressable>
-                <Text style={styles.link}>{t("auth.login.registerLink")}</Text>
+                <Text style={[styles.link, { color: colors.primary }]}>
+                  {t("auth.login.registerLink")}
+                </Text>
               </Pressable>
             </Link>
           </View>
@@ -201,118 +257,92 @@ export default function LoginScreen() {
   );
 }
 
-function createStyles(colors: typeof lightColors) {
-  return StyleSheet.create({
-    container: {
-      flex: 1,
-      backgroundColor: colors.background,
-    },
-    scrollContent: {
-      flexGrow: 1,
-      justifyContent: "center",
-      padding: spacing.xl,
-    },
-    header: {
-      alignItems: "center",
-      marginBottom: spacing["2xl"],
-    },
-    logo: {
-      fontSize: 42,
-      fontWeight: "bold",
-      color: colors.primary,
-      marginBottom: spacing.sm,
-    },
-    subtitle: {
-      fontSize: 16,
-      color: colors.textSecondary,
-    },
-    form: {
-      backgroundColor: colors.backgroundSecondary,
-      borderRadius: borderRadius.lg,
-      borderWidth: 2,
-      borderColor: colors.border,
-      padding: spacing.xl,
-    },
-    errorContainer: {
-      backgroundColor: colors.error + "20",
-      borderWidth: 2,
-      borderColor: colors.error,
-      borderRadius: borderRadius.md,
-      padding: spacing.md,
-      marginBottom: spacing.lg,
-    },
-    errorText: {
-      color: colors.error,
-      fontSize: 14,
-      textAlign: "center",
-    },
-    inputGroup: {
-      marginBottom: spacing.lg,
-    },
-    label: {
-      fontSize: 14,
-      fontWeight: "600",
-      color: colors.text,
-      marginBottom: spacing.xs,
-    },
-    input: {
-      backgroundColor: colors.background,
-      borderWidth: 2,
-      borderColor: colors.border,
-      borderRadius: borderRadius.md,
-      padding: spacing.md,
-      fontSize: 16,
-      color: colors.text,
-    },
-    passwordContainer: {
-      flexDirection: "row",
-      alignItems: "center",
-      backgroundColor: colors.background,
-      borderWidth: 2,
-      borderColor: colors.border,
-      borderRadius: borderRadius.md,
-    },
-    passwordInput: {
-      flex: 1,
-      padding: spacing.md,
-      fontSize: 16,
-      color: colors.text,
-    },
-    eyeButton: {
-      padding: spacing.md,
-    },
-    button: {
-      backgroundColor: colors.primary,
-      borderWidth: 2,
-      borderColor: colors.border,
-      borderRadius: borderRadius.md,
-      padding: spacing.md,
-      alignItems: "center",
-      marginTop: spacing.md,
-    },
-    buttonDisabled: {
-      opacity: 0.6,
-    },
-    buttonText: {
-      fontSize: 16,
-      fontWeight: "bold",
-      color: colors.primaryText,
-    },
-    footer: {
-      flexDirection: "row",
-      justifyContent: "center",
-      alignItems: "center",
-      marginTop: spacing.xl,
-      gap: spacing.xs,
-    },
-    footerText: {
-      fontSize: 14,
-      color: colors.textSecondary,
-    },
-    link: {
-      fontSize: 14,
-      fontWeight: "600",
-      color: colors.primary,
-    },
-  });
-}
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  scrollContent: {
+    flexGrow: 1,
+    justifyContent: "center",
+    padding: spacing.xl,
+  },
+  header: {
+    alignItems: "center",
+    marginBottom: spacing["2xl"],
+  },
+  logo: {
+    ...typography.titleLarge,
+    fontSize: 42,
+    marginBottom: spacing.sm,
+  },
+  form: {
+    borderRadius: 12,
+    borderWidth: 2,
+    padding: spacing.xl,
+  },
+  errorContainer: {
+    borderWidth: 2,
+    borderRadius: 8,
+    padding: spacing.md,
+    marginBottom: spacing.lg,
+  },
+  errorText: {
+    ...typography.bodySmall,
+    textAlign: "center",
+  },
+  inputGroup: {
+    marginBottom: spacing.lg,
+  },
+  label: {
+    ...typography.label,
+    marginBottom: spacing.xs,
+  },
+  input: {
+    ...borders.input,
+    padding: spacing.md,
+    ...typography.body,
+    ...shadows.sm,
+  },
+  inputFocused: {
+    ...shadows.md,
+  },
+  passwordContainer: {
+    flexDirection: "row",
+    alignItems: "center",
+    ...borders.input,
+    ...shadows.sm,
+  },
+  passwordInput: {
+    flex: 1,
+    padding: spacing.md,
+    ...typography.body,
+  },
+  eyeButton: {
+    padding: spacing.md,
+  },
+  button: {
+    ...borders.button,
+    padding: spacing.md,
+    alignItems: "center",
+    marginTop: spacing.md,
+  },
+  buttonDisabled: {
+    opacity: 0.6,
+  },
+  buttonText: {
+    ...typography.button,
+  },
+  footer: {
+    flexDirection: "row",
+    justifyContent: "center",
+    alignItems: "center",
+    marginTop: spacing.xl,
+    gap: spacing.xs,
+  },
+  footerText: {
+    ...typography.bodySmall,
+  },
+  link: {
+    ...typography.label,
+  },
+});

--- a/mobile/app/(auth)/register.tsx
+++ b/mobile/app/(auth)/register.tsx
@@ -9,21 +9,20 @@ import {
   Platform,
   ScrollView,
   ActivityIndicator,
-  useColorScheme,
 } from "react-native";
 import { Ionicons } from "@expo/vector-icons";
 import { Link } from "expo-router";
 import { useTranslation } from "react-i18next";
 import { useAuth } from "@/contexts/auth-context";
 import { LanguageContext } from "@/contexts/language-context";
-import { lightColors, darkColors, spacing, borderRadius } from "@/constants";
+import { useThemeColors } from "@/hooks/use-theme-colors";
+import { spacing, typography, borders, shadows } from "@/constants";
 
 export default function RegisterScreen() {
   const { t } = useTranslation();
   const { register } = useAuth();
   const languageContext = useContext(LanguageContext);
-  const colorScheme = useColorScheme();
-  const colors = colorScheme === "dark" ? darkColors : lightColors;
+  const colors = useThemeColors();
 
   const [username, setUsername] = useState("");
   const [email, setEmail] = useState("");
@@ -33,6 +32,7 @@ export default function RegisterScreen() {
   const [showConfirmPassword, setShowConfirmPassword] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [focusedField, setFocusedField] = useState<string | null>(null);
 
   const handleRegister = async () => {
     if (
@@ -77,11 +77,9 @@ export default function RegisterScreen() {
     }
   };
 
-  const styles = createStyles(colors);
-
   return (
     <KeyboardAvoidingView
-      style={styles.container}
+      style={[styles.container, { backgroundColor: colors.background }]}
       behavior={Platform.OS === "ios" ? "padding" : "height"}
     >
       <ScrollView
@@ -89,23 +87,56 @@ export default function RegisterScreen() {
         keyboardShouldPersistTaps="handled"
       >
         <View style={styles.header}>
-          <Text style={styles.logo}>Membooks</Text>
-          <Text style={styles.subtitle}>{t("auth.register.subtitle")}</Text>
+          <Text style={[styles.logo, { color: colors.primary }]}>Membooks</Text>
+          <Text style={[styles.subtitle, { color: colors.textSecondary }]}>
+            {t("auth.register.subtitle")}
+          </Text>
         </View>
 
-        <View style={styles.form}>
+        <View
+          style={[
+            styles.form,
+            {
+              backgroundColor: colors.backgroundSecondary,
+              borderColor: colors.border,
+            },
+          ]}
+        >
           {error && (
-            <View style={styles.errorContainer}>
-              <Text style={styles.errorText}>{error}</Text>
+            <View
+              style={[
+                styles.errorContainer,
+                {
+                  backgroundColor: colors.error + "20",
+                  borderColor: colors.error,
+                },
+              ]}
+            >
+              <Text style={[styles.errorText, { color: colors.error }]}>
+                {error}
+              </Text>
             </View>
           )}
 
           <View style={styles.inputGroup}>
-            <Text style={styles.label}>{t("auth.username")}</Text>
+            <Text style={[styles.label, { color: colors.text }]}>
+              {t("auth.username")}
+            </Text>
             <TextInput
-              style={styles.input}
+              style={[
+                styles.input,
+                {
+                  backgroundColor: colors.background,
+                  borderColor: focusedField === "username" ? colors.primary : colors.border,
+                  color: colors.text,
+                  shadowColor: colors.shadow,
+                },
+                focusedField === "username" && styles.inputFocused,
+              ]}
               value={username}
               onChangeText={setUsername}
+              onFocus={() => setFocusedField("username")}
+              onBlur={() => setFocusedField(null)}
               placeholder={t("auth.usernamePlaceholder")}
               placeholderTextColor={colors.textMuted}
               autoCapitalize="none"
@@ -115,11 +146,24 @@ export default function RegisterScreen() {
           </View>
 
           <View style={styles.inputGroup}>
-            <Text style={styles.label}>{t("auth.email")}</Text>
+            <Text style={[styles.label, { color: colors.text }]}>
+              {t("auth.email")}
+            </Text>
             <TextInput
-              style={styles.input}
+              style={[
+                styles.input,
+                {
+                  backgroundColor: colors.background,
+                  borderColor: focusedField === "email" ? colors.primary : colors.border,
+                  color: colors.text,
+                  shadowColor: colors.shadow,
+                },
+                focusedField === "email" && styles.inputFocused,
+              ]}
               value={email}
               onChangeText={setEmail}
+              onFocus={() => setFocusedField("email")}
+              onBlur={() => setFocusedField(null)}
               placeholder={t("auth.emailPlaceholder")}
               placeholderTextColor={colors.textMuted}
               keyboardType="email-address"
@@ -130,12 +174,26 @@ export default function RegisterScreen() {
           </View>
 
           <View style={styles.inputGroup}>
-            <Text style={styles.label}>{t("auth.password")}</Text>
-            <View style={styles.passwordContainer}>
+            <Text style={[styles.label, { color: colors.text }]}>
+              {t("auth.password")}
+            </Text>
+            <View
+              style={[
+                styles.passwordContainer,
+                {
+                  backgroundColor: colors.background,
+                  borderColor: focusedField === "password" ? colors.primary : colors.border,
+                  shadowColor: colors.shadow,
+                },
+                focusedField === "password" && styles.inputFocused,
+              ]}
+            >
               <TextInput
-                style={styles.passwordInput}
+                style={[styles.passwordInput, { color: colors.text }]}
                 value={password}
                 onChangeText={setPassword}
+                onFocus={() => setFocusedField("password")}
+                onBlur={() => setFocusedField(null)}
                 placeholder={t("auth.passwordPlaceholder")}
                 placeholderTextColor={colors.textMuted}
                 secureTextEntry={!showPassword}
@@ -157,12 +215,26 @@ export default function RegisterScreen() {
           </View>
 
           <View style={styles.inputGroup}>
-            <Text style={styles.label}>{t("auth.confirmPassword")}</Text>
-            <View style={styles.passwordContainer}>
+            <Text style={[styles.label, { color: colors.text }]}>
+              {t("auth.confirmPassword")}
+            </Text>
+            <View
+              style={[
+                styles.passwordContainer,
+                {
+                  backgroundColor: colors.background,
+                  borderColor: focusedField === "confirmPassword" ? colors.primary : colors.border,
+                  shadowColor: colors.shadow,
+                },
+                focusedField === "confirmPassword" && styles.inputFocused,
+              ]}
+            >
               <TextInput
-                style={styles.passwordInput}
+                style={[styles.passwordInput, { color: colors.text }]}
                 value={confirmPassword}
                 onChangeText={setConfirmPassword}
+                onFocus={() => setFocusedField("confirmPassword")}
+                onBlur={() => setFocusedField(null)}
                 placeholder={t("auth.confirmPasswordPlaceholder")}
                 placeholderTextColor={colors.textMuted}
                 secureTextEntry={!showConfirmPassword}
@@ -184,24 +256,35 @@ export default function RegisterScreen() {
           </View>
 
           <Pressable
-            style={[styles.button, isLoading && styles.buttonDisabled]}
+            style={[
+              styles.button,
+              {
+                backgroundColor: colors.primary,
+                borderColor: colors.border,
+              },
+              isLoading && styles.buttonDisabled,
+            ]}
             onPress={handleRegister}
             disabled={isLoading}
           >
             {isLoading ? (
               <ActivityIndicator color={colors.primaryText} />
             ) : (
-              <Text style={styles.buttonText}>{t("auth.register.button")}</Text>
+              <Text style={[styles.buttonText, { color: colors.primaryText }]}>
+                {t("auth.register.button")}
+              </Text>
             )}
           </Pressable>
 
           <View style={styles.footer}>
-            <Text style={styles.footerText}>
+            <Text style={[styles.footerText, { color: colors.textSecondary }]}>
               {t("auth.register.hasAccount")}
             </Text>
             <Link href="/(auth)/login" asChild>
               <Pressable>
-                <Text style={styles.link}>{t("auth.register.loginLink")}</Text>
+                <Text style={[styles.link, { color: colors.primary }]}>
+                  {t("auth.register.loginLink")}
+                </Text>
               </Pressable>
             </Link>
           </View>
@@ -211,118 +294,95 @@ export default function RegisterScreen() {
   );
 }
 
-function createStyles(colors: typeof lightColors) {
-  return StyleSheet.create({
-    container: {
-      flex: 1,
-      backgroundColor: colors.background,
-    },
-    scrollContent: {
-      flexGrow: 1,
-      justifyContent: "center",
-      padding: spacing.xl,
-    },
-    header: {
-      alignItems: "center",
-      marginBottom: spacing["2xl"],
-    },
-    logo: {
-      fontSize: 42,
-      fontWeight: "bold",
-      color: colors.primary,
-      marginBottom: spacing.sm,
-    },
-    subtitle: {
-      fontSize: 16,
-      color: colors.textSecondary,
-    },
-    form: {
-      backgroundColor: colors.backgroundSecondary,
-      borderRadius: borderRadius.lg,
-      borderWidth: 2,
-      borderColor: colors.border,
-      padding: spacing.xl,
-    },
-    errorContainer: {
-      backgroundColor: colors.error + "20",
-      borderWidth: 2,
-      borderColor: colors.error,
-      borderRadius: borderRadius.md,
-      padding: spacing.md,
-      marginBottom: spacing.lg,
-    },
-    errorText: {
-      color: colors.error,
-      fontSize: 14,
-      textAlign: "center",
-    },
-    inputGroup: {
-      marginBottom: spacing.lg,
-    },
-    label: {
-      fontSize: 14,
-      fontWeight: "600",
-      color: colors.text,
-      marginBottom: spacing.xs,
-    },
-    input: {
-      backgroundColor: colors.background,
-      borderWidth: 2,
-      borderColor: colors.border,
-      borderRadius: borderRadius.md,
-      padding: spacing.md,
-      fontSize: 16,
-      color: colors.text,
-    },
-    passwordContainer: {
-      flexDirection: "row",
-      alignItems: "center",
-      backgroundColor: colors.background,
-      borderWidth: 2,
-      borderColor: colors.border,
-      borderRadius: borderRadius.md,
-    },
-    passwordInput: {
-      flex: 1,
-      padding: spacing.md,
-      fontSize: 16,
-      color: colors.text,
-    },
-    eyeButton: {
-      padding: spacing.md,
-    },
-    button: {
-      backgroundColor: colors.primary,
-      borderWidth: 2,
-      borderColor: colors.border,
-      borderRadius: borderRadius.md,
-      padding: spacing.md,
-      alignItems: "center",
-      marginTop: spacing.md,
-    },
-    buttonDisabled: {
-      opacity: 0.6,
-    },
-    buttonText: {
-      fontSize: 16,
-      fontWeight: "bold",
-      color: colors.primaryText,
-    },
-    footer: {
-      flexDirection: "row",
-      justifyContent: "center",
-      alignItems: "center",
-      marginTop: spacing.xl,
-      gap: spacing.xs,
-    },
-    footerText: {
-      fontSize: 14,
-      color: colors.textSecondary,
-    },
-    link: {
-      fontSize: 14,
-      fontWeight: "600",
-      color: colors.primary,
-    },
-  });
-}
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  scrollContent: {
+    flexGrow: 1,
+    justifyContent: "center",
+    padding: spacing.xl,
+  },
+  header: {
+    alignItems: "center",
+    marginBottom: spacing["2xl"],
+  },
+  logo: {
+    ...typography.titleLarge,
+    fontSize: 42,
+    marginBottom: spacing.sm,
+  },
+  subtitle: {
+    ...typography.body,
+  },
+  form: {
+    borderRadius: 12,
+    borderWidth: 2,
+    padding: spacing.xl,
+  },
+  errorContainer: {
+    borderWidth: 2,
+    borderRadius: 8,
+    padding: spacing.md,
+    marginBottom: spacing.lg,
+  },
+  errorText: {
+    ...typography.bodySmall,
+    textAlign: "center",
+  },
+  inputGroup: {
+    marginBottom: spacing.lg,
+  },
+  label: {
+    ...typography.label,
+    marginBottom: spacing.xs,
+  },
+  input: {
+    ...borders.input,
+    padding: spacing.md,
+    ...typography.body,
+    ...shadows.sm,
+  },
+  inputFocused: {
+    ...shadows.md,
+  },
+  passwordContainer: {
+    flexDirection: "row",
+    alignItems: "center",
+    ...borders.input,
+    ...shadows.sm,
+  },
+  passwordInput: {
+    flex: 1,
+    padding: spacing.md,
+    ...typography.body,
+  },
+  eyeButton: {
+    padding: spacing.md,
+  },
+  button: {
+    ...borders.button,
+    padding: spacing.md,
+    alignItems: "center",
+    marginTop: spacing.md,
+  },
+  buttonDisabled: {
+    opacity: 0.6,
+  },
+  buttonText: {
+    ...typography.button,
+  },
+  footer: {
+    flexDirection: "row",
+    justifyContent: "center",
+    alignItems: "center",
+    marginTop: spacing.xl,
+    gap: spacing.xs,
+  },
+  footerText: {
+    ...typography.bodySmall,
+  },
+  link: {
+    ...typography.label,
+  },
+});

--- a/mobile/app/(tabs)/index.tsx
+++ b/mobile/app/(tabs)/index.tsx
@@ -198,6 +198,25 @@ export default function Home() {
           </View>
 
           {/* Books list */}
+          {libraryItems.length === 0 && (
+            <View style={styles.emptyContainer}>
+              <View
+                style={[
+                  styles.emptyCard,
+                  {
+                    backgroundColor: colors.backgroundSecondary,
+                    borderColor: colors.border,
+                    shadowColor: colors.shadow,
+                  },
+                ]}
+              >
+                <Ionicons name="book-outline" size={48} color={colors.textSecondary} />
+                <Text style={[styles.emptyText, { color: colors.textSecondary }]}>
+                  {t('home.emptyLibrary')}
+                </Text>
+              </View>
+            </View>
+          )}
           <View style={styles.list}>
             {libraryItems.map((item, index) => (
               <View key={item.data.id}>
@@ -241,9 +260,21 @@ export default function Home() {
 
           {sortedWishlist.length === 0 ? (
             <View style={styles.emptyContainer}>
-              <Text style={[styles.emptyText, { color: colors.textSecondary }]}>
-                {t('home.emptyWishlist')}
-              </Text>
+              <View
+                style={[
+                  styles.emptyCard,
+                  {
+                    backgroundColor: colors.backgroundSecondary,
+                    borderColor: colors.border,
+                    shadowColor: colors.shadow,
+                  },
+                ]}
+              >
+                <Ionicons name="heart-outline" size={48} color={colors.textSecondary} />
+                <Text style={[styles.emptyText, { color: colors.textSecondary }]}>
+                  {t('home.emptyWishlist')}
+                </Text>
+              </View>
             </View>
           ) : (
             <View style={styles.list}>
@@ -286,9 +317,21 @@ export default function Home() {
 
           {upcomingBooks.length === 0 ? (
             <View style={styles.emptyContainer}>
-              <Text style={[styles.emptyText, { color: colors.textSecondary }]}>
-                {t('home.emptyUpcoming')}
-              </Text>
+              <View
+                style={[
+                  styles.emptyCard,
+                  {
+                    backgroundColor: colors.backgroundSecondary,
+                    borderColor: colors.border,
+                    shadowColor: colors.shadow,
+                  },
+                ]}
+              >
+                <Ionicons name="megaphone-outline" size={48} color={colors.textSecondary} />
+                <Text style={[styles.emptyText, { color: colors.textSecondary }]}>
+                  {t('home.emptyUpcoming')}
+                </Text>
+              </View>
             </View>
           ) : (
             <View style={styles.list}>
@@ -469,6 +512,13 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
     alignItems: 'center',
     paddingTop: spacing['2xl'],
+  },
+  emptyCard: {
+    padding: spacing['2xl'],
+    alignItems: 'center',
+    gap: spacing.md,
+    ...borders.card,
+    ...shadows.md,
   },
   emptyText: {
     ...typography.body,

--- a/mobile/app/(tabs)/proposals.tsx
+++ b/mobile/app/(tabs)/proposals.tsx
@@ -6,6 +6,7 @@
 import { View, Text, StyleSheet } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useTranslation } from 'react-i18next';
+import { Ionicons } from '@expo/vector-icons';
 import { useThemeColors } from '@/hooks/use-theme-colors';
 import { spacing, typography, borders, shadows } from '@/constants';
 
@@ -40,8 +41,12 @@ export default function ProposalsScreen() {
             },
           ]}
         >
-          <Text style={[styles.placeholderText, { color: colors.textSecondary }]}>
+          <Ionicons name="bulb-outline" size={64} color={colors.accent1} />
+          <Text style={[styles.placeholderTitle, { color: colors.text }]}>
             {t('home.comingSoon')}
+          </Text>
+          <Text style={[styles.placeholderSubtitle, { color: colors.textSecondary }]}>
+            {t('proposals.subtitle')}
           </Text>
         </View>
       </View>
@@ -66,10 +71,15 @@ const styles = StyleSheet.create({
   placeholderCard: {
     padding: spacing['2xl'],
     alignItems: 'center',
+    gap: spacing.md,
     ...borders.card,
     ...shadows.md,
   },
-  placeholderText: {
+  placeholderTitle: {
+    ...typography.subtitle,
+  },
+  placeholderSubtitle: {
     ...typography.body,
+    textAlign: 'center',
   },
 });

--- a/mobile/locales/en.json
+++ b/mobile/locales/en.json
@@ -61,8 +61,13 @@
       "wishlist": "Wishlist",
       "releases": "Coming"
     },
+    "emptyLibrary": "Your library is empty. Search for books to add!",
     "emptyWishlist": "Your wishlist is empty. Search for books to add!",
-    "emptyUpcoming": "No upcoming releases. Add books with future release dates to your wishlist!"
+    "emptyUpcoming": "No upcoming releases. Add books with future release dates to your wishlist!",
+    "comingSoon": "Coming Soon"
+  },
+  "proposals": {
+    "subtitle": "Get personalized book recommendations based on your reading history and preferences."
   },
   "wishlist": {
     "moveToOwned": "I got it!",

--- a/mobile/locales/fr.json
+++ b/mobile/locales/fr.json
@@ -61,8 +61,13 @@
       "wishlist": "Wishlist",
       "releases": "À venir"
     },
+    "emptyLibrary": "Votre bibliotheque est vide. Recherchez des livres a ajouter !",
     "emptyWishlist": "Votre wishlist est vide. Recherchez des livres a ajouter !",
-    "emptyUpcoming": "Aucune sortie a venir. Ajoutez des livres avec une date de sortie future a votre wishlist !"
+    "emptyUpcoming": "Aucune sortie a venir. Ajoutez des livres avec une date de sortie future a votre wishlist !",
+    "comingSoon": "Bientot disponible"
+  },
+  "proposals": {
+    "subtitle": "Recevez des recommandations de livres basees sur votre historique de lecture et vos preferences."
   },
   "wishlist": {
     "moveToOwned": "Je l'ai !",


### PR DESCRIPTION
## Summary
- Replace `useColorScheme()` with `useThemeColors()` hook in auth screens so manual theme switching works correctly
- Add Neo-Memphis styled empty state cards with Ionicons (book-outline, heart-outline, megaphone-outline) on home screen tabs
- Enhance proposals placeholder with bulb icon, subtitle text, and styled card
- Add input focus states with accent border color and larger shadow on focus
- Add translation keys for new empty states and proposals subtitle (en/fr)
- Add `KeyboardAvoidingView` to global test setup mock

## Test plan
- [x] `bun run test` — all 215 tests pass (106 services + 41 contexts + 68 components/hooks)
- [x] Manual: verify auth screens respect theme setting (system/light/dark)
- [x] Manual: verify empty states display icons and styled cards
- [x] Manual: verify input focus highlights border in accent color

Closes #69

🤖 Generated with [Claude Code](https://claude.com/claude-code)