### PR TITLE
feat: add Fly.io configuration for API and Web

### DIFF
--- a/api/fly.toml
+++ b/api/fly.toml
@@ -1,0 +1,30 @@
+app = 'membooks-api'
+primary_region = 'cdg'
+
+[build]
+
+[deploy]
+  release_command = 'bunx drizzle-kit push'
+
+[env]
+  PORT = '3000'
+  NODE_ENV = 'production'
+
+[http_service]
+  internal_port = 3000
+  force_https = true
+  auto_stop_machines = 'stop'
+  auto_start_machines = true
+  min_machines_running = 0
+
+[[http_service.checks]]
+  grace_period = '10s'
+  interval = '30s'
+  method = 'GET'
+  timeout = '5s'
+  path = '/health'
+
+[[vm]]
+  memory = '256mb'
+  cpu_kind = 'shared'
+  cpus = 1

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -29,10 +29,10 @@ RUN bun run build
 # copy production dependencies and source code into final image
 FROM base AS release
 COPY --from=install /temp/prod/node_modules node_modules
-COPY --from=prerelease /usr/src/app/dist dist
+COPY --from=prerelease /usr/src/app/src src
 COPY --from=prerelease /usr/src/app/package.json .
 
 # run the app
 USER bun
 EXPOSE 3001/tcp
-ENTRYPOINT [ "bun", "run", "dist/server.js" ]
+ENTRYPOINT [ "bun", "run", "src/server.ts" ]

--- a/web/fly.toml
+++ b/web/fly.toml
@@ -1,0 +1,21 @@
+app = 'membooks-web'
+primary_region = 'cdg'
+
+[build]
+
+[env]
+  PORT = '3001'
+  NODE_ENV = 'production'
+  API_URL = 'http://membooks-api.internal:3000'
+
+[http_service]
+  internal_port = 3001
+  force_https = true
+  auto_stop_machines = 'stop'
+  auto_start_machines = true
+  min_machines_running = 0
+
+[[vm]]
+  memory = '256mb'
+  cpu_kind = 'shared'
+  cpus = 1


### PR DESCRIPTION
## Summary
- Add `api/fly.toml` — Fly.io config for the API (health check, Drizzle migrations via `release_command`)
- Add `web/fly.toml` — Fly.io config for the Web (proxy vers API via réseau interne `.internal`)
- Fix `web/Dockerfile` — l'entrypoint `dist/server.js` n'existait pas, corrigé vers `src/server.ts`

### Configuration

**API** (`api/fly.toml`):
| Paramètre | Valeur |
|-----------|--------|
| Région | `cdg` (Paris) |
| Port interne | 3000 |
| VM | shared-cpu-1x, 256 MB |
| Health check | `GET /health` toutes les 30s |
| Release command | `bunx drizzle-kit push` (migrations auto) |

**Web** (`web/fly.toml`):
| Paramètre | Valeur |
|-----------|--------|
| Région | `cdg` (Paris) |
| Port interne | 3001 |
| VM | shared-cpu-1x, 256 MB |
| API_URL | `http://membooks-api.internal:3000` (réseau privé Fly.io) |

### Commandes de déploiement
```bash
# API
cd api && fly launch   # première fois
cd api && fly deploy   # déploiements suivants

# Web
cd web && fly launch   # première fois
cd web && fly deploy   # déploiements suivants

# Secrets API (à configurer avant le premier deploy)
cd api && fly secrets set \
  JWT_SECRET="$(openssl rand -base64 32)" \
  DATABASE_URL="postgres://..." \
  STRIPE_SECRET_KEY="sk_live_..." \
  STRIPE_WEBHOOK_SECRET="whsec_..." \
  STRIPE_PREMIUM_PRICE_ID="price_..." \
  ADMIN_EMAILS="admin@example.com" \
  CORS_ORIGINS="https://membooks-web.fly.dev"
```

### Fix Dockerfile web
`build.ts` génère les assets frontend dans `dist/` mais ne compile pas le serveur. L'entrypoint `dist/server.js` n'existait pas → corrigé vers `src/server.ts` (Bun exécute TypeScript nativement, et c'est ce que fait le script `start` du package.json).

Closes #74

## Test plan
- [x] 205 tests API passent
- [x] 155 tests Web passent
- [x] `fly launch` depuis `api/` crée l'app correctement
- [ ] `fly launch` depuis `web/` crée l'app correctement
- [ ] `fly deploy` des deux services fonctionne
- [ ] La communication web→API via `.internal` fonctionne

🤖 Generated with [Claude Code](https://claude.com/claude-code)