### PR TITLE
feat(api): add security headers middleware

### DIFF
--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -48,6 +48,14 @@ const app = new Elysia()
       },
     })
   )
+  .onAfterHandle(({ set }) => {
+    set.headers["strict-transport-security"] = "max-age=63072000; includeSubDomains; preload";
+    set.headers["x-content-type-options"] = "nosniff";
+    set.headers["x-frame-options"] = "DENY";
+    set.headers["x-xss-protection"] = "0";
+    set.headers["referrer-policy"] = "strict-origin-when-cross-origin";
+    set.headers["permissions-policy"] = "camera=(), microphone=(), geolocation=()";
+  })
   .onRequest(({ request }) => {
     requestTimings.set(request, performance.now());
   })


### PR DESCRIPTION
## Summary
- Add an `onAfterHandle` middleware that injecte les headers de sécurité OWASP sur toutes les réponses API

### Headers ajoutés
| Header | Valeur | Rôle |
|--------|--------|------|
| `Strict-Transport-Security` | `max-age=63072000; includeSubDomains; preload` | Force HTTPS pendant 2 ans |
| `X-Content-Type-Options` | `nosniff` | Empêche le MIME-type sniffing |
| `X-Frame-Options` | `DENY` | Bloque l'embedding en iframe |
| `X-XSS-Protection` | `0` | Désactivé (au profit de CSP) |
| `Referrer-Policy` | `strict-origin-when-cross-origin` | Limite les infos de referrer |
| `Permissions-Policy` | `camera=(), microphone=(), geolocation=()` | Bloque les APIs sensibles du navigateur |

Closes #77

## Test plan
- [x] 205 tests API passent

🤖 Generated with [Claude Code](https://claude.com/claude-code)