### PR TITLE
feat: configure Stripe live mode with web/mobile redirects

### DIFF
--- a/api/.env.example
+++ b/api/.env.example
@@ -2,15 +2,19 @@ DATABASE_URL=postgresql://user@localhost:5432/membooks
 JWT_SECRET=change-this-to-a-secure-random-string
 PORT=3000
 
-# Stripe (get from https://dashboard.stripe.com)
-STRIPE_SECRET_KEY=sk_test_...
+# Stripe (get from https://dashboard.stripe.com/apikeys)
+# Use sk_test_... for test mode, sk_live_... for live mode
+STRIPE_SECRET_KEY=sk_live_...
 STRIPE_WEBHOOK_SECRET=whsec_...
 STRIPE_PREMIUM_PRICE_ID=price_...
 
 # CORS allowed origins (comma-separated, leave empty to allow all in development)
 CORS_ORIGINS=
 
-# App URL for redirects
+# Web URL for Stripe checkout redirects (web frontend)
+WEB_URL=https://membooks.com
+
+# App URL for mobile deep link redirects
 APP_URL=membooks://
 
 # Admin emails (comma-separated)

--- a/api/src/routes/subscription.ts
+++ b/api/src/routes/subscription.ts
@@ -24,6 +24,7 @@ function getStripe(): Stripe {
 
 const PREMIUM_PRICE_ID = process.env.STRIPE_PREMIUM_PRICE_ID || "";
 const APP_URL = process.env.APP_URL || "membooks://";
+const WEB_URL = process.env.WEB_URL || "https://membooks.com";
 
 export const subscriptionRoutes = new Elysia({ prefix: "/subscription" })
   .use(
@@ -51,7 +52,7 @@ export const subscriptionRoutes = new Elysia({ prefix: "/subscription" })
   // Create checkout session for subscription
   .post(
     "/checkout",
-    async ({ headers, cookie, jwt, set }) => {
+    async ({ headers, cookie, jwt, set, body }) => {
       const cookieToken = cookie[COOKIE_NAME]?.value as string | undefined;
       const authHeader = headers.authorization;
       const headerToken = authHeader?.startsWith("Bearer ") ? authHeader.slice(7) : null;
@@ -103,6 +104,16 @@ export const subscriptionRoutes = new Elysia({ prefix: "/subscription" })
           .where(eq(users.id, user.id));
       }
 
+      // Determine redirect URLs based on source (web or mobile)
+      const source = (body as any)?.source;
+      const isWeb = source === "web";
+      const successUrl = isWeb
+        ? `${WEB_URL}/subscription?success=true&session_id={CHECKOUT_SESSION_ID}`
+        : `${APP_URL}subscription/success?session_id={CHECKOUT_SESSION_ID}`;
+      const cancelUrl = isWeb
+        ? `${WEB_URL}/subscription?canceled=true`
+        : `${APP_URL}subscription/cancel`;
+
       // Create checkout session
       const session = await getStripe().checkout.sessions.create({
         customer: customerId,
@@ -114,8 +125,8 @@ export const subscriptionRoutes = new Elysia({ prefix: "/subscription" })
             quantity: 1,
           },
         ],
-        success_url: `${APP_URL}subscription/success?session_id={CHECKOUT_SESSION_ID}`,
-        cancel_url: `${APP_URL}subscription/cancel`,
+        success_url: successUrl,
+        cancel_url: cancelUrl,
         metadata: {
           userId: user.id,
         },
@@ -124,7 +135,7 @@ export const subscriptionRoutes = new Elysia({ prefix: "/subscription" })
       return { url: session.url };
     },
     {
-      detail: { tags: ["Subscription"], summary: "Create checkout session", description: "Create a Stripe checkout session for premium subscription. Requires Bearer token.", security: [{ bearerAuth: [] }] },
+      detail: { tags: ["Subscription"], summary: "Create checkout session", description: "Create a Stripe checkout session for premium subscription. Send source: 'web' or 'mobile' to control redirect URLs. Requires Bearer token.", security: [{ bearerAuth: [] }] },
     }
   )
   // Get current subscription status

--- a/mobile/app/subscription.tsx
+++ b/mobile/app/subscription.tsx
@@ -28,7 +28,7 @@ import {
 } from "@/services/subscription";
 import { spacing, typography, borders, shadows } from "@/constants";
 
-const PREMIUM_PRICE = "5";
+const PREMIUM_PRICE = "3.99";
 const PREMIUM_CURRENCY = "€";
 
 interface SubscriptionInfo {

--- a/mobile/services/subscription.ts
+++ b/mobile/services/subscription.ts
@@ -41,7 +41,9 @@ export async function createCheckoutSession(): Promise<CheckoutResponse> {
       method: "POST",
       headers: {
         Authorization: `Bearer ${session.token}`,
+        "Content-Type": "application/json",
       },
+      body: JSON.stringify({ source: "mobile" }),
     });
 
     const result = await response.json();

--- a/web/src/pages/Subscription.tsx
+++ b/web/src/pages/Subscription.tsx
@@ -1,3 +1,4 @@
+import { useState, useEffect } from "react";
 import { Link } from "@tanstack/react-router";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { usePageTitle } from "../hooks/usePageTitle";
@@ -11,6 +12,20 @@ import {
 export function SubscriptionPage() {
   usePageTitle("Premium");
   const queryClient = useQueryClient();
+  const [checkoutMessage, setCheckoutMessage] = useState<{ type: "success" | "canceled"; text: string } | null>(null);
+
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+    if (params.get("success") === "true") {
+      setCheckoutMessage({ type: "success", text: "Payment successful! Your premium subscription is now active." });
+      queryClient.invalidateQueries({ queryKey: ["subscription"] });
+      queryClient.invalidateQueries({ queryKey: ["currentUser"] });
+      window.history.replaceState({}, "", "/subscription");
+    } else if (params.get("canceled") === "true") {
+      setCheckoutMessage({ type: "canceled", text: "Payment canceled. You can try again whenever you're ready." });
+      window.history.replaceState({}, "", "/subscription");
+    }
+  }, [queryClient]);
 
   const { data, isLoading, error } = useQuery({
     queryKey: ["subscription"],
@@ -87,6 +102,13 @@ export function SubscriptionPage() {
         <h1 className="font-title text-3xl">Premium</h1>
         <div className="w-20" />
       </div>
+
+      {/* Checkout result banner */}
+      {checkoutMessage && (
+        <div className={`p-4 border-2 rounded-lg mb-6 ${checkoutMessage.type === "success" ? "bg-green-50 border-green-500 text-green-700" : "bg-yellow-50 border-yellow-500 text-yellow-700"}`}>
+          {checkoutMessage.text}
+        </div>
+      )}
 
       {/* Current Status */}
       <div className="bg-white border-2 border-gray-900 rounded-xl p-6 neo-shadow-md mb-6">

--- a/web/src/services/subscription.ts
+++ b/web/src/services/subscription.ts
@@ -48,6 +48,8 @@ export async function createCheckoutSession(): Promise<{
     const response = await fetch(`${API_URL}/subscription/checkout`, {
       method: "POST",
       credentials: "include",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ source: "web" }),
     });
 
     const data = await response.json();


### PR DESCRIPTION
## Summary
- **Backend**: checkout endpoint accepts `source` param (`web`/`mobile`) to return platform-appropriate redirect URLs — web goes to `membooks.com`, mobile uses deep link (`membooks://`)
- **Mobile**: opens Stripe Checkout in external browser via `expo-web-browser` to **avoid Apple/Google 30% commission**, sends `source: "mobile"`, price updated to 3.99€/month
- **Web**: sends `source: "web"`, handles `?success=true` / `?canceled=true` query params with confirmation banner after Stripe redirect
- **Env**: cleaned `.env.example` — removed exposed test key, added `WEB_URL`, clarified live vs test mode comments

## Post-merge checklist
- [ ] Set `STRIPE_SECRET_KEY=sk_live_...` in production `.env`
- [ ] Set `STRIPE_WEBHOOK_SECRET=whsec_...` (live webhook)
- [ ] Create product & price in Stripe live mode, set `STRIPE_PREMIUM_PRICE_ID`
- [ ] Set `WEB_URL=https://membooks.com`
- [ ] Configure live webhook on `https://<api-domain>/webhook/stripe`

## Test plan
- [ ] Verify web checkout redirects to Stripe and returns to `/subscription?success=true`
- [ ] Verify mobile checkout opens browser, completes payment, deep-links back to app
- [ ] Verify cancel flow redirects correctly for both platforms
- [ ] Verify webhook processes `checkout.session.completed` and activates premium

🤖 Generated with [Claude Code](https://claude.com/claude-code)