### PR TITLE
feat(mobile): configure Android signing via EAS

### DIFF
--- a/mobile/.gitignore
+++ b/mobile/.gitignore
@@ -4,3 +4,9 @@
 
 expo-env.d.ts
 # @end expo-cli
+
+# Android signing (never commit keystores or credentials)
+*.jks
+*.keystore
+credentials.json
+google-services.json

--- a/mobile/eas.json
+++ b/mobile/eas.json
@@ -7,7 +7,10 @@
     "development": {
       "developmentClient": true,
       "distribution": "internal",
-      "channel": "development"
+      "channel": "development",
+      "android": {
+        "credentialsSource": "remote"
+      }
     },
     "preview": {
       "distribution": "internal",
@@ -16,7 +19,8 @@
         "simulator": false
       },
       "android": {
-        "buildType": "apk"
+        "buildType": "apk",
+        "credentialsSource": "remote"
       }
     },
     "production": {
@@ -26,7 +30,8 @@
         "distribution": "store"
       },
       "android": {
-        "buildType": "app-bundle"
+        "buildType": "app-bundle",
+        "credentialsSource": "remote"
       }
     }
   },
@@ -38,7 +43,8 @@
         "appleTeamId": "${APPLE_TEAM_ID}"
       },
       "android": {
-        "serviceAccountKeyPath": "${GOOGLE_SERVICE_ACCOUNT_KEY_PATH}"
+        "serviceAccountKeyPath": "${GOOGLE_SERVICE_ACCOUNT_KEY_PATH}",
+        "track": "internal"
       }
     }
   }


### PR DESCRIPTION
Closes #32

## Summary
- **EAS credentials remote**: `credentialsSource: "remote"` sur tous les profils de build Android (development, preview, production) — EAS génère et stocke le keystore de manière sécurisée dans le cloud Expo
- **Submit track**: ajout de `track: "internal"` pour le premier upload Play Store (test interne avant production publique)
- **Gitignore**: protection contre le commit accidentel de fichiers sensibles (`*.jks`, `*.keystore`, `credentials.json`, `google-services.json`)

## Pourquoi `credentialsSource: "remote"` ?
EAS gère le keystore automatiquement :
- Génération sécurisée à la première build
- Stocké chiffré dans le cloud Expo (backup automatique)
- Pas de risque de perte du keystore (perte = impossibilité de MAJ l'app)
- Récupérable via `eas credentials` à tout moment

## Checklist issue
- [x] Générer un keystore de production (EAS le gère automatiquement au premier `eas build`)
- [x] Sauvegarder le keystore en lieu sûr (stocké dans Expo cloud, récupérable via `eas credentials`)
- [x] Configurer le package name dans `app.json` (déjà `com.membooks.app`)
- [ ] Tester un build Android production (AAB) → après merge

## Post-merge
```bash
cd mobile

# Premier build production Android (AAB) — EAS génère le keystore automatiquement
eas build --profile production --platform android

# Pour récupérer/sauvegarder le keystore localement
eas credentials --platform android

# Pour soumettre au Play Store (track internal)
eas submit --profile production --platform android
```

## Test plan
- [ ] `eas build --profile preview --platform android` → vérifier que le build APK passe
- [ ] `eas build --profile production --platform android` → vérifier que l'AAB est généré
- [ ] `eas credentials --platform android` → vérifier que le keystore est récupérable

🤖 Generated with [Claude Code](https://claude.com/claude-code)