### PR TITLE
feat(mobile): configure iOS signing and provisioning via EAS

### DIFF
--- a/mobile/.gitignore
+++ b/mobile/.gitignore
@@ -10,3 +10,9 @@ expo-env.d.ts
 *.keystore
 credentials.json
 google-services.json
+
+# iOS signing (never commit certificates or provisioning profiles)
+*.p12
+*.mobileprovision
+*.provisionprofile
+AuthKey_*.p8

--- a/mobile/app.json
+++ b/mobile/app.json
@@ -11,7 +11,10 @@
     "ios": {
       "supportsTablet": true,
       "bundleIdentifier": "com.membooks.app",
-      "usesAppleSignIn": true
+      "usesAppleSignIn": true,
+      "infoPlist": {
+        "ITSAppUsesNonExemptEncryption": false
+      }
     },
     "android": {
       "package": "com.membooks.app",

--- a/mobile/eas.json
+++ b/mobile/eas.json
@@ -8,6 +8,9 @@
       "developmentClient": true,
       "distribution": "internal",
       "channel": "development",
+      "ios": {
+        "credentialsSource": "remote"
+      },
       "android": {
         "credentialsSource": "remote"
       }
@@ -16,7 +19,8 @@
       "distribution": "internal",
       "channel": "preview",
       "ios": {
-        "simulator": false
+        "simulator": false,
+        "credentialsSource": "remote"
       },
       "android": {
         "buildType": "apk",
@@ -27,7 +31,9 @@
       "autoIncrement": true,
       "channel": "production",
       "ios": {
-        "distribution": "store"
+        "distribution": "store",
+        "credentialsSource": "remote",
+        "autoIncrement": "buildNumber"
       },
       "android": {
         "buildType": "app-bundle",


### PR DESCRIPTION
Closes #31

## Summary
- **EAS credentials remote**: `credentialsSource: "remote"` sur tous les profils iOS (development, preview, production) — EAS gère automatiquement les certificats de distribution et provisioning profiles via le cloud Expo
- **Auto-increment buildNumber**: le `buildNumber` iOS s'incrémente automatiquement à chaque build production (requis par App Store Connect)
- **Export compliance**: `ITSAppUsesNonExemptEncryption: false` dans `infoPlist` pour éviter le popup de conformité export à chaque soumission TestFlight/App Store (l'app utilise uniquement HTTPS standard)
- **Gitignore**: protection contre le commit de fichiers sensibles iOS (`.p12`, `.mobileprovision`, `.provisionprofile`, `AuthKey_*.p8`)

## Comment EAS gère le signing iOS
Au premier `eas build --platform ios`, EAS va :
1. Te demander de te connecter à ton compte Apple Developer
2. Générer automatiquement un certificat de distribution
3. Créer le provisioning profile (ad-hoc pour preview, App Store pour production)
4. Stocker tout dans le cloud Expo (chiffré, récupérable via `eas credentials`)

## Checklist issue
- [x] Créer un compte Apple Developer (prérequis, à vérifier avant build)
- [x] Configurer les certificats via EAS (`credentialsSource: "remote"`)
- [x] Créer le provisioning profile de distribution (EAS le fait au premier build)
- [x] Configurer le bundle identifier dans `app.json` (déjà `com.membooks.app`)
- [ ] Tester un build iOS production → après merge

## Post-merge
```bash
cd mobile

# Premier build production iOS — EAS configure les certificats automatiquement
eas build --profile production --platform ios

# Pour vérifier/gérer les credentials
eas credentials --platform ios

# Pour soumettre à l'App Store
eas submit --profile production --platform ios
```

## Test plan
- [ ] `eas build --profile preview --platform ios` → vérifier le build ad-hoc
- [ ] `eas build --profile production --platform ios` → vérifier le build App Store
- [ ] `eas credentials --platform ios` → vérifier certificat et provisioning profile
- [ ] Vérifier que le buildNumber s'auto-incrémente entre deux builds

🤖 Generated with [Claude Code](https://claude.com/claude-code)