### PR TITLE
feat(api): validate env vars at startup — reject weak JWT_SECRET

### DIFF
--- a/api/src/utils/env.ts
+++ b/api/src/utils/env.ts
@@ -12,6 +12,8 @@ const OPTIONAL_VARS = [
   "SMTP_PASS",
 ] as const;
 
+const JWT_SECRET_MIN_LENGTH = 32;
+
 export function validateEnv(): void {
   const missing: string[] = [];
 
@@ -23,6 +25,15 @@ export function validateEnv(): void {
 
   if (missing.length > 0) {
     logger.error("missing required environment variables", { missing });
+    process.exit(1);
+  }
+
+  // JWT_SECRET must be long enough for HS256 (256 bits minimum)
+  const jwtSecret = process.env.JWT_SECRET!;
+  if (jwtSecret.length < JWT_SECRET_MIN_LENGTH) {
+    logger.error(
+      `JWT_SECRET is too short (${jwtSecret.length} chars). Minimum ${JWT_SECRET_MIN_LENGTH} characters required for secure signing.`
+    );
     process.exit(1);
   }
 


### PR DESCRIPTION
Closes #75

## Summary
- **JWT_SECRET min length**: le serveur refuse de démarrer si `JWT_SECRET` fait moins de 32 caractères (minimum pour HS256 sécurisé), avec un message d'erreur clair
- Les autres points de l'issue étaient déjà résolus dans le code existant

## Checklist issue
- [x] Vérifier au démarrage que les variables requises sont définies (`JWT_SECRET`, `DATABASE_URL`) — déjà en place dans `env.ts`
- [x] Avertir (warn) si les variables optionnelles manquent (`STRIPE_SECRET_KEY`, `ADMIN_EMAILS`, `SMTP_HOST`) — déjà en place
- [x] Refuser de démarrer si `JWT_SECRET` est absent ou trop court — **ajouté dans cette PR** (min 32 chars)
- [x] Supprimer le fallback `"fallback-secret-for-development"` dans `subscription.ts` — déjà supprimé (tous les usages sont `process.env.JWT_SECRET!`)

## Comportement
```
# JWT_SECRET absent → exit immédiat
ERROR: missing required environment variables { missing: ["JWT_SECRET"] }

# JWT_SECRET trop court (ex: "secret123") → exit immédiat  
ERROR: JWT_SECRET is too short (9 chars). Minimum 32 characters required for secure signing.

# Variables optionnelles manquantes → warning, serveur démarre
WARN: missing optional environment variables — some features will be unavailable { missing: ["STRIPE_SECRET_KEY", ...] }
```

## Test plan
- [ ] Démarrer l'API sans `JWT_SECRET` → vérifier exit avec message clair
- [ ] Démarrer avec un `JWT_SECRET` de 10 chars → vérifier exit avec message de longueur
- [ ] Démarrer avec un `JWT_SECRET` de 32+ chars → vérifier démarrage normal
- [ ] Démarrer sans `STRIPE_SECRET_KEY` → vérifier warning (pas de crash)

🤖 Generated with [Claude Code](https://claude.com/claude-code)