### PR TITLE
fix(mobile): nettoyer les credentials Supabase (#30)

### DIFF
--- a/mobile/.env.example
+++ b/mobile/.env.example
@@ -1,0 +1,6 @@
+EXPO_PUBLIC_API_URL=http://localhost:3000
+
+# Google Sign-In (get these from Google Cloud Console)
+EXPO_PUBLIC_GOOGLE_WEB_CLIENT_ID=your-web-client-id.apps.googleusercontent.com
+EXPO_PUBLIC_GOOGLE_IOS_CLIENT_ID=your-ios-client-id.apps.googleusercontent.com
+EXPO_PUBLIC_GOOGLE_ANDROID_CLIENT_ID=your-android-client-id.apps.googleusercontent.com

--- a/mobile/.gitignore
+++ b/mobile/.gitignore
@@ -5,6 +5,11 @@
 expo-env.d.ts
 # @end expo-cli
 
+# Environment variables
+.env
+.env*.local
+!.env.example
+
 # Android signing (never commit keystores or credentials)
 *.jks
 *.keystore


### PR DESCRIPTION
## Summary
- Remove unused Supabase credentials (`SUPABASE_PASSWORD`, `EXPO_PUBLIC_SUPABASE_URL`, `EXPO_PUBLIC_SUPABASE_KEY`) from `mobile/.env`
- Add `mobile/.env.example` documenting the required environment variables (without Supabase)
- Add `.env` / `.env*.local` to `mobile/.gitignore` to prevent accidental commits of secrets

Closes #30

## Test plan
- [x] Verified no Supabase imports or usage anywhere in the codebase
- [x] `bun run lint` — 0 errors
- [x] `bun run test` — all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)