### PR TITLE
fix(mobile): remove unnecessary permissions

### DIFF
--- a/mobile/app.json
+++ b/mobile/app.json
@@ -33,7 +33,6 @@
       "predictiveBackGestureEnabled": false,
       "permissions": [
         "android.permission.CAMERA",
-        "android.permission.RECORD_AUDIO",
         "android.permission.RECEIVE_BOOT_COMPLETED"
       ],
       "intentFilters": [
@@ -65,9 +64,7 @@
       [
         "expo-camera",
         {
-          "cameraPermission": "Allow $(PRODUCT_NAME) to access your camera",
-          "microphonePermission": "Allow $(PRODUCT_NAME) to access your microphone",
-          "recordAudioAndroid": true
+          "cameraPermission": "Allow $(PRODUCT_NAME) to access your camera to scan book barcodes"
         }
       ],
       "expo-apple-authentication",


### PR DESCRIPTION
## Summary
- Removed `android.permission.RECORD_AUDIO` — camera is only used for barcode scanning, not video/audio
- Removed `microphonePermission` iOS usage description and `recordAudioAndroid` flag from expo-camera plugin
- Updated `cameraPermission` message to specify barcode scanning purpose

## Permissions audit

| Permission | Status | Reason |
|---|---|---|
| `CAMERA` | Kept | Used for ISBN barcode scanning |
| `RECORD_AUDIO` | **Removed** | No audio/video recording in the app |
| `RECEIVE_BOOT_COMPLETED` | Kept | Required for push notifications |

Closes #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)